### PR TITLE
Add way to only download last n videos from total url file

### DIFF
--- a/toledo-dl.py
+++ b/toledo-dl.py
@@ -35,18 +35,21 @@ def dl_url(toledo_url):
     # For some reason cd command doesn't work on Windows. Took it out of the subprocess call.
     os.chdir(dir_path)
 
-    # Download videos using youtube-dl
-    # Check whether the last argument is an integer. If True only download last n videos of all videos from every link in urlq
-    to_download = sys.argv[-1]
-    if isinstance(to_download, int):
-        while to_download > 0:
-            print('Downloading video {}/{}'.format(len(videos)-to_download, len(videos)))
-            subprocess.run('youtube-dl -f best kaltura:{}:{}'.format(videos[len(videos)-to_download][0], videos[len(videos)-to_download][1]), shell=True)
-            to_download += -1
+    # Download videos using youtube-dl, if there were any videos found on the page
+    if len(videos) > 0:
+        # Check whether the last argument is an integer. If True only download last n videos of all videos from every link in urls
+        if sys.argv[-1].isdigit():
+            to_download = int(sys.argv[-1])
+            while to_download > 0:
+                print('Downloading video {}/{}'.format(len(videos)-to_download+1, len(videos)))
+                subprocess.run('youtube-dl -f best kaltura:{}:{}'.format(videos[len(videos)-to_download][0], videos[len(videos)-to_download][1]), shell=True)
+                to_download += -1
+        else:
+            for idx, video in enumerate(videos):
+                print('Downloading video {}/{}'.format(idx + 1, len(videos)))
+                subprocess.run('youtube-dl -f best kaltura:{}:{}'.format(video[0], video[1]), shell=True)
     else:
-        for idx, video in enumerate(videos):
-            print('Downloading video {}/{}'.format(idx + 1, len(videos)))
-            subprocess.run('youtube-dl -f best kaltura:{}:{}'.format(video[0], video[1]), shell=True)
+        print("No videos found, check if urls are correct or if cookies are still valid.")
 
     # Change back to parent folder after downloading all videos in list.
     os.chdir('..')

--- a/toledo-dl.py
+++ b/toledo-dl.py
@@ -36,9 +36,18 @@ def dl_url(toledo_url):
     os.chdir(dir_path)
 
     # Download videos using youtube-dl
-    for idx, video in enumerate(videos):
-        print('Downloading video {}/{}'.format(idx + 1, len(videos)))
-        subprocess.run('youtube-dl -f best kaltura:{}:{}'.format(video[0], video[1]), shell=True)
+    # Check whether the last argument is an integer. If True only download last n videos of all videos from every link in urlq
+    to_download = sys.argv[-1]
+    if isinstance(to_download, int):
+        while to_download > 0:
+            print('Downloading video {}/{}'.format(len(videos)-to_download, len(videos)))
+            subprocess.run('youtube-dl -f best kaltura:{}:{}'.format(videos[len(videos)-to_download][0], videos[len(videos)-to_download][1]), shell=True)
+            to_download += -1
+    else:
+        for idx, video in enumerate(videos):
+            print('Downloading video {}/{}'.format(idx + 1, len(videos)))
+            subprocess.run('youtube-dl -f best kaltura:{}:{}'.format(video[0], video[1]), shell=True)
+
     # Change back to parent folder after downloading all videos in list.
     os.chdir('..')
 


### PR DESCRIPTION
I added a bit of code to make it possible to only download a specified amount of videos from last to first.
this would make it possible to download only the last video from a toledo course page.
This is accomplished through adding a third argument when running the script. It works exactly the same as before if the last sys argument is not an integer.
syntax:
`python3 toledo-dl.py urls.txt *optional integer here*`
example:
`python3 toledo-dl.py urls.txt 3` -> this downloads the last 3 videos from **all** available videos from the urls file

Aside from this I also added a print statement when it doesn't detect any videos to download.